### PR TITLE
check.go: Always pad mlid to 16 digits

### DIFF
--- a/check.go
+++ b/check.go
@@ -79,7 +79,7 @@ func check(r *Response) string {
 	h.Write([]byte(challenge))
 	h.Write([]byte("\n"))
 	// We don't store the Wii Friend Code in the database with the w. The hash requires it.
-	h.Write([]byte(fmt.Sprintf("w%d", mlid)))
+	h.Write([]byte(fmt.Sprintf("w%016d", mlid)))
 	h.Write([]byte("\n"))
 	h.Write([]byte(mailFlag))
 	h.Write([]byte("\n"))


### PR DESCRIPTION
Closes #2
I have -1 clues on how to test this. But the function is named "sprintf" so it works just like the one in C right