### PR TITLE
Validate emails before sending

### DIFF
--- a/send.go
+++ b/send.go
@@ -5,11 +5,12 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/gin-gonic/gin"
 	"net/http"
 	"net/smtp"
 	"regexp"
 	"strings"
+
+	"github.com/gin-gonic/gin"
 )
 
 var (
@@ -176,6 +177,14 @@ func send(c *gin.Context) {
 
 		for _, recipient := range emailRecipients {
 			// PC Mail
+			// First validate email
+			valid := validateEmailAddress(recipient)
+			if !valid {
+				// Not valid, move on to the next email.
+				// We do not want to toggle error otherwise it will try and send again.
+				continue
+			}
+
 			// Production utilizes Amazon SES.
 			auth := smtp.PlainAuth("", config.SMTPUsername, config.SMTPPassword, config.SMTPHost)
 			err = smtp.SendMail(
@@ -185,6 +194,7 @@ func send(c *gin.Context) {
 				[]string{recipient},
 				[]byte(parsedMail),
 			)
+
 			if err != nil {
 				cgi.AddMailResponse(index, 551, "SMTP error.")
 				ReportErrorGin(c, err)

--- a/utils.go
+++ b/utils.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"math/rand"
 	"net"
+	"net/mail"
 	"strconv"
 	"strings"
 	"time"
@@ -115,7 +116,12 @@ func RandStringBytesMaskImprSrc(n int) string {
 // (i.e. The amazing Sentry error where a user emailed the domain '1679')
 // Furthermore, we also check if the domain actually exists.
 func validateEmailAddress(email string) bool {
-	parts := strings.Split(email, "@")
+	address, err := mail.ParseAddress(email)
+	if err != nil {
+		return false
+	}
+
+	parts := strings.Split(address.Address, "@")
 	if len(parts) != 2 {
 		return false
 	}

--- a/utils.go
+++ b/utils.go
@@ -2,15 +2,18 @@ package main
 
 import (
 	"fmt"
+	"log"
+	"math/rand"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/WiiLink24/nwc24"
 	"github.com/getsentry/sentry-go"
 	sentrygin "github.com/getsentry/sentry-go/gin"
 	"github.com/gin-gonic/gin"
 	"github.com/logrusorgru/aurora/v4"
-	"log"
-	"math/rand"
-	"strconv"
-	"time"
 )
 
 const (
@@ -106,4 +109,25 @@ func RandStringBytesMaskImprSrc(n int) string {
 	}
 
 	return string(b)
+}
+
+// For some reason, the Wii doesn't validate that the email address is valid.
+// (i.e. The amazing Sentry error where a user emailed the domain '1679')
+// Furthermore, we also check if the domain actually exists.
+func validateEmailAddress(email string) bool {
+	parts := strings.Split(email, "@")
+	if len(parts) != 2 {
+		return false
+	}
+
+	domain := parts[1]
+
+	// Search the MX records for the supposed domain.
+	records, err := net.LookupMX(domain)
+	if err != nil || len(records) == 0 {
+		// No email servers.
+		return false
+	}
+
+	return true
 }


### PR DESCRIPTION
Sentry reported an error where a recipient for an email did not exist. The exact error was `Level: Error
554 Transaction failed: Invalid domain name: '1679'.`

This raised two possible bugs:
- A recipient can have a valid domain but no MX records
- A recipient is completely invalid (The Wii does not validate this)

This PR resolves both issues by checking if the recipient is a valid email address, then secondly checking if the domain has an MX record.