### PR TITLE
Remove null bytes from mail

### DIFF
--- a/send.go
+++ b/send.go
@@ -140,16 +140,16 @@ func send(c *gin.Context) {
 		// Replace all @wii.com references in the
 		// friend request email with our own domain.
 		// Format: w9004342343324713@wii.com <mailto:w9004342343324713@wii.com>
-		parsedMail = strings.Replace(parsedMail,
+		parsedMail = strings.ReplaceAll(parsedMail,
 			"wii.com",
-			"rc24.xyz",
-			-1)
+			"rc24.xyz")
 
 		// We should also replace mail.wiilink24.com.
-		parsedMail = strings.Replace(parsedMail,
+		parsedMail = strings.ReplaceAll(parsedMail,
 			"mail.wiilink24.com",
-			"rc24.xyz",
-			-1)
+			"rc24.xyz")
+
+		parsedMail = strings.ReplaceAll(parsedMail, "\x00", "")
 
 		var didError bool
 		for _, recipient := range wiiRecipients {


### PR DESCRIPTION
See [Sentry error](https://wiilink.sentry.io/issues/69452900/events/85fe1cd86a274945b572a3341f489c53/): ERROR: invalid byte sequence for encoding "UTF8": 0x00 (SQLSTATE 22021)

Removing all null bytes in this fashion should be fine as it is against RFC 5321 to send raw binary through SMTP (exceptions exist but extensions are required which we don't support.) Furthermore, the Wii will never actually send null bytes through the service per the decompilation. Observing the headers in the Sentry issue, this request was not sent from a Wii as it lacks the User-Agent: `WiiConnect24/some version`.