### PR TITLE
fix: parse emails as plaintext

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,6 +89,7 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/k3a/html2text v1.4.0 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -161,6 +161,7 @@ github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 h1:EwtI+Al+DeppwYX2oX
 github.com/google/pprof v0.0.0-20260402051712-545e8a4df936/go.mod h1:MxpfABSjhmINe3F1It9d+8exIHFvUqtLIRCdOGNXqiI=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/hashicorp/go-version v1.9.0 h1:CeOIz6k+LoN3qX9Z0tyQrPtiB1DFYRPfCIBtaXPSCnA=
@@ -177,6 +178,9 @@ github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/k3a/html2text v1.4.0 h1:e4xarrVgZST+h+5C/fbA6AI49VFDSlEWMmIcDWcxsd0=
+github.com/k3a/html2text v1.4.0/go.mod h1:ieEXykM67iT8lTvEWBh6fhpH4B23kB9OMKPdIBmgUqA=
 github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
 github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
@@ -244,6 +248,8 @@ github.com/secure-systems-lab/go-securesystemslib v0.11.0/go.mod h1:+PMOTjUGwHj2
 github.com/shirou/gopsutil/v4 v4.26.4 h1:B4SXVbcwTyrocPHEmWBC4uCYr4Xcu3MK1TXqbprAOWY=
 github.com/shirou/gopsutil/v4 v4.26.4/go.mod h1:LZ6ewCSkBqUpvSOf+LsTGnRinC6iaNUNMGBtDkJBaLQ=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -373,6 +379,7 @@ golang.org/x/image v0.39.0/go.mod h1:sIbmppfU+xFLPIG0FoVUTvyBMmgng1/XAMhQ2ft0hpA
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
 golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
+golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
@@ -403,6 +410,7 @@ golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=
 golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=
 golang.org/x/time v0.15.0/go.mod h1:Y4YMaQmXwGQZoFaVFk4YpCt4FLQMYKZe9oeV/f4MSno=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/inbound.go
+++ b/inbound.go
@@ -75,7 +75,7 @@ func readMultipartMessage(message io.Reader, boundary string) (*Message, error) 
 
 		if strings.HasPrefix(contentType, "image/") {
 			msg.Attachment = body
-		} else if strings.HasPrefix(contentType, "text/") {
+		} else if strings.HasPrefix(contentType, "text/plain") {
 			msg.Text = removeNonUTF8Characters(string(body))
 		} else {
 			// We can't handle this, discard.

--- a/inbound.go
+++ b/inbound.go
@@ -17,6 +17,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/k3a/html2text"
 	"golang.org/x/image/draw"
 
 	// Importing as a side effect allows for the image library to check for these formats
@@ -49,6 +50,7 @@ func readMultipartMessage(message io.Reader, boundary string) (*Message, error) 
 	multipartReader := multipart.NewReader(message, boundary)
 
 	var msg Message
+	var fallbackHTML string
 	for {
 		p, err := multipartReader.NextPart()
 		if errors.Is(err, io.EOF) {
@@ -75,12 +77,19 @@ func readMultipartMessage(message io.Reader, boundary string) (*Message, error) 
 
 		if strings.HasPrefix(contentType, "image/") {
 			msg.Attachment = body
-		} else if strings.HasPrefix(contentType, "text/plain") {
+		} else if strings.HasPrefix(contentType, "text/html") {
+			fallbackHTML = string(body)
+		} else if strings.HasPrefix(contentType, "text/") {
 			msg.Text = removeNonUTF8Characters(string(body))
 		} else {
 			// We can't handle this, discard.
 			continue
 		}
+	}
+
+	// In the unlikely context of the multipart email being HTML only, cleanup and serve the HTML.
+	if len(msg.Text) == 0 && len(fallbackHTML) > 0 {
+		msg.Text = removeNonUTF8Characters(html2text.HTML2Text(fallbackHTML))
 	}
 
 	return &msg, nil
@@ -172,8 +181,14 @@ func readMessage(email *s3.GetObjectOutput) (*Message, error) {
 		if err != nil {
 			return nil, err
 		}
+	} else if strings.HasPrefix(mediaType, "text/html") {
+		msgBytes, err := io.ReadAll(msg.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		parts.Text = removeNonUTF8Characters(html2text.HTML2Text(string(msgBytes)))
 	} else if strings.HasPrefix(mediaType, "text/") {
-		// Body should be the message.
 		msgBytes, err := io.ReadAll(msg.Body)
 		if err != nil {
 			return nil, err

--- a/message_decode_test.go
+++ b/message_decode_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"mime"
+	"net/mail"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestEmailDecode(_t *testing.T) {
+	message := `Content-Type: multipart/alternative;
+ boundary="------------uPU7sYJfD0qHhIHRNc1JfkQy"
+Message-ID: <025c664c-3c5d-4c27-bb41-1c89e77e21fd@btinternet.com>
+Date: Sat, 2 May 2026 21:47:54 +0100
+MIME-Version: 1.0
+User-Agent: Mozilla Thunderbird
+Content-Language: en-GB
+To: contact@harrywalker.uk
+From: Harry Walker <anonymised@btinternet.com>
+Subject: Test email
+
+This is a multi-part message in MIME format.
+--------------uPU7sYJfD0qHhIHRNc1JfkQy
+Content-Type: text/plain; charset=UTF-8; format=flowed
+Content-Transfer-Encoding: 7bit
+
+This is a test email to see how HTML formatting works
+
+
+  wow a header
+
+
+
+*some bold* /and italics/
+
+--------------uPU7sYJfD0qHhIHRNc1JfkQy
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+<!DOCTYPE html>
+<html>
+  <head>
+
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+  </head>
+  <body>
+    <p>This is a test email to see how HTML formatting works</p>
+    <p><br>
+    </p>
+    <h1>wow a header</h1>
+    <p><br>
+    </p>
+    <p><br>
+    </p>
+    <p><b>some bold</b>Â <i>and italics</i></p>
+  </body>
+</html>
+
+--------------uPU7sYJfD0qHhIHRNc1JfkQy--
+`
+	expectedTo := "contact@harrywalker.uk"
+	expectedFrom := "anonymised@btinternet.com"
+	expectedSubject := "Test email"
+	expectedText := `This is a test email to see how HTML formatting works
+
+
+  wow a header
+
+
+
+*some bold* /and italics/
+`
+
+	r := strings.NewReader(message)
+
+	msg, err := mail.ReadMessage(r)
+	if err != nil {
+		_t.Fatal(err)
+	}
+
+	fromRaw := msg.Header.Get("From")
+	from, err := mail.ParseAddress(fromRaw)
+	if err != nil {
+		_t.Fatal(err)
+	}
+	if from.Address != expectedFrom {
+		_t.Errorf("Incorrect from address.\n\n Expected: '%s'\n\n Got: '%s'", expectedFrom, from.Address)
+	}
+
+	toRaw := msg.Header.Get("To")
+	toList, err := mail.ParseAddressList(toRaw)
+	if err != nil {
+		_t.Fatal(err)
+	}
+	if !slices.ContainsFunc(toList, func(toAddress *mail.Address) bool {
+		return toAddress.Address == expectedTo
+	}) {
+		_t.Errorf("Incorrect to address.\n\n Expected: '%s'\n\n Got: '%s'", expectedTo, toList)
+	}
+
+	subject := msg.Header.Get("Subject")
+	if subject != expectedSubject {
+		_t.Errorf("Incorrect subject.\n\n Expected: '%s'\n\n Got: '%s'", expectedSubject, subject)
+	}
+
+	mediaType, params, err := mime.ParseMediaType(msg.Header.Get("Content-Type"))
+	if err != nil {
+		_t.Fatal(err)
+	}
+
+	parts := &Message{}
+	if strings.HasPrefix(mediaType, "multipart/") {
+		parts, err = readMultipartMessage(msg.Body, params["boundary"])
+		if err != nil {
+			_t.Fatal(err)
+		}
+	}
+
+	if parts.Text != expectedText {
+		_t.Errorf("Incorrect body.\n\n Expected: '%s'\n\n Got: '%s'", expectedText, parts.Text)
+	}
+}


### PR DESCRIPTION
This PR adds proper handling for HTML emails. Multipart messages now default to non-HTML text (as all major email clients send HTML messages as multiparts with both HTML and plaintext), while having a proper fallback to strip HTML tags when only HTML is available. 

This also adds a basic unit test to ensure we are parsing content properly from multipart emails. 